### PR TITLE
small regex error

### DIFF
--- a/letterboxd-lists-progress.user.js
+++ b/letterboxd-lists-progress.user.js
@@ -90,7 +90,7 @@ let passByLists = function () {
 			$progress.find(".lf-progress-percentage").text($where.find(".progress-percentage").text());
 			$progress.find(".lf-progress-bar").css({"width": $where.find(".progress-percentage").text() + "%"});
 			$progress.find(".lf-progress-count").text($where.find(".js-progress-count").text());
-			$progress.find(".lf-progress-total").text($where.find(".progress-count").text().match(/of ([0-9]+)/)[1]);
+			$progress.find(".lf-progress-total").text($where.find(".progress-count").text().match(/of ([0-9|,]+)/)[1]);
 
 			$self.after($progress).addClass("lf-no-margin");
 		});


### PR DESCRIPTION
Lists with >= 1000 movies had all numbers after the comma cut off. For example "You've watched x of 1" if it should have been "You've watched x of 1,245".